### PR TITLE
dropped 5.4,5.5; added 7, 7.1 & dependency matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,33 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
+  - 7
+  - 7.1
   - hhvm
+
+## Build matrix for lowest and highest possible targets
+matrix:
+  include:
+    - php: 5.6
+      env: dependencies=lowest
+    - php: 7
+      env: dependencies=lowest
+    - php: 7.1
+      env: dependencies=lowest
+    - php: hhvm
+      env: dependencies=lowest
+    - php: 5.6
+      env: dependencies=highest
+    - php: 7
+      env: dependencies=highest
+    - php: 7.1
+      env: dependencies=highest
+    - php: hhvm
+      env: dependencies=highest
+  allow_failures:
+    - php: hhvm
+    - php: 7.1
 
 before_script:
   - composer self-update


### PR DESCRIPTION
modified the `.travis.yml` file
- dropped php versions 5.4 and 5.5
- added php versions 7 and 7.1
- added dependency matrix

resolves #3 